### PR TITLE
use least privilege & send to group

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Secondly right click on the `script/Send-Teams-Message` file and select copy as 
 Lastly open Powershell (with the black logo). Type a `.` and paste the copied path afterwards.
 
 If you want to send Messages to specific people press enter afterwards and enter mail address after mail address.
+You can also add multiple mail addresses (like from excel) `"user1@example.com","user2@example.com"`.
 
 When you want to send mail to all people type `-All` afterwards. You can exclude specific people with `-ExcludeDisplayName "Karla Kolumna"`.
 

--- a/script/Send-TeamsMessage.ps1
+++ b/script/Send-TeamsMessage.ps1
@@ -106,7 +106,7 @@ if ($PSCmdlet.ParameterSetName -eq "Group") {
     $users = Get-MgGroupMember -GroupId $groupId -All -Property $properties
     $additionalProperties = @("id")
     $additionalProperties += $users[0].AdditionalProperties.Keys | ForEach-Object { return @{"Name" = $_.ToString(); Expression = [scriptblock]::Create("`$_.AdditionalProperties['$_']") } }
-    $users = $users | Select-Object -Property $additionalProperties
+    $users = $users | Select-Object -Property $additionalProperties | Where-Object { $_.Mail -ne $context.Account }
 }
 else {
     $users = Get-MgUser -All -Property $properties
@@ -115,7 +115,7 @@ else {
         $users = $users | Where-Object { $UserEmail -contains $_.Mail }
     }
     elseif ($PSCmdlet.ParameterSetName -eq "All") {
-        $users = $users | Where-Object { $_.UserType -ne "Guest" }
+        $users = $users | Where-Object { $_.UserType -ne "Guest" -and $_.Mail -ne $context.Account }
     }
 }
 

--- a/script/Send-TeamsMessage.ps1
+++ b/script/Send-TeamsMessage.ps1
@@ -49,7 +49,7 @@ param (
     [Parameter(ParameterSetName = "All", Mandatory)]
     [switch]$All,
 
-    # Exclude members by DisplayName.
+    # Exclude members by DisplayName. When you use this, you must have a Admin role. 
     [Parameter(ParameterSetName = "All")]
     [String[]]
     $ExcludeDisplayName
@@ -63,7 +63,17 @@ $ErrorActionPreference = "Stop"
 #endregion
 
 #region Connect
-Connect-MgGraph -Scopes "User.Read.All", "Chat.Create", "ChatMessage.Send"
+$scopes = @("Chat.Create", "ChatMessage.Send", "")
+if ($PSBoundParameters.ContainsKey("ExcludeDisplayName")) {
+    $scopes[2] = "User.Read.All"
+    Write-Warning -MessageData "You are using the ExcludeDisplayName parameter. This requires the User.Read.All scope, which is an Admin scope. Make sure you have the necessary permissions to run this script."
+    Write-Information -InformationAction Continue -MessageData "If you don't have the User.Read.All scope, you can remove the ExcludeDisplayName parameter to use the User.ReadBasic.All scope instead."
+}
+else {
+    $scopes[2] = "User.ReadBasic.All"
+}
+
+Connect-MgGraph -Scopes $scopes
 #endregion
 
 #region Get users

--- a/script/Send-TeamsMessage.ps1
+++ b/script/Send-TeamsMessage.ps1
@@ -147,8 +147,15 @@ foreach ($user in $users) {
             }
         )
     }
-    $chat = New-MgChat -BodyParameter $params
-
+    try {
+        $chat = New-MgChat -BodyParameter $params
+    }
+    catch {
+        # The problem is most likely, that we hit throttling
+        Start-Sleep -Seconds 1
+        $chat = New-MgChat -BodyParameter $params
+    }
+    
     $userMessage = $Message -replace "{{GivenName}}", $user.GivenName
     $body = @{
         body = @{
@@ -156,7 +163,15 @@ foreach ($user in $users) {
             contentType = "html"
         }
     }
-    $chatMessage = New-MgChatMessage -ChatId $chat.Id -BodyParameter $body
 
+    try {
+        $chatMessage = New-MgChatMessage -ChatId $chat.Id -BodyParameter $body
+    }
+    catch {
+        # The problem is most likely, that we hit throttling
+        Start-Sleep -Seconds 1
+        $chatMessage = New-MgChatMessage -ChatId $chat.Id -BodyParameter $body
+    }
+    
     Write-Information -InformationAction Continue -MessageData "Message sent to $($user.Mail) - $($chatMessage.Id)"
 }

--- a/script/Send-TeamsMessage.ps1
+++ b/script/Send-TeamsMessage.ps1
@@ -62,7 +62,7 @@ $ErrorActionPreference = "Stop"
 $scopes = @("Chat.Create", "ChatMessage.Send", "")
 if ($PSBoundParameters.ContainsKey("ExcludeDisplayName")) {
     $scopes[2] = "User.Read.All"
-    Write-Warning -MessageData "You are using the ExcludeDisplayName parameter. This requires the User.Read.All scope, which is an Admin scope. Make sure you have the necessary permissions to run this script."
+    Write-Information -InformationAction Continue -MessageData "You are using the ExcludeDisplayName parameter. This requires the User.Read.All scope, which is an Admin scope. Make sure you have the necessary permissions to run this script."
     Write-Information -InformationAction Continue -MessageData "If you don't have the User.Read.All scope, you can remove the ExcludeDisplayName parameter to use the User.ReadBasic.All scope instead."
 }
 else {

--- a/script/Send-TeamsMessage.ps1
+++ b/script/Send-TeamsMessage.ps1
@@ -73,7 +73,12 @@ Connect-MgGraph -Scopes $scopes
 #endregion
 
 #region Get users
-$users = Get-MgUser -All -Property id, givenName, mail, userType, displayName
+$properties = @("id", "givenName", "mail", "userType")
+if ($PSBoundParameters.ContainsKey("ExcludeDisplayName")) {
+    $properties += "displayName"
+}
+
+$users = Get-MgUser -All -Property $properties
 $context = Get-MgContext
 
 if ($PSCmdlet.ParameterSetName -eq "Specific") {

--- a/script/Send-TeamsMessage.ps1
+++ b/script/Send-TeamsMessage.ps1
@@ -104,6 +104,9 @@ if ($PSCmdlet.ParameterSetName -eq "Group") {
         throw "Group '$Group' not found. Please check the group name."
     }
     $users = Get-MgGroupMember -GroupId $groupId -All -Property $properties
+    $additionalProperties = @("id")
+    $additionalProperties += $users[0].AdditionalProperties.Keys | ForEach-Object { return @{"Name" = $_.ToString(); Expression = [scriptblock]::Create("`$_.AdditionalProperties['$_']") } }
+    $users = $users | Select-Object -Property $additionalProperties
 }
 else {
     $users = Get-MgUser -All -Property $properties

--- a/script/Send-TeamsMessage.ps1
+++ b/script/Send-TeamsMessage.ps1
@@ -89,6 +89,7 @@ elseif ($PSBoundParameters.ContainsKey("ExcludeDisplayName")) {
 
 $scopes = @("Chat.Create", "ChatMessage.Send", $additionalScope)
 Connect-MgGraph -Scopes $scopes
+$context = Get-MgContext
 #endregion
 
 #region Get users
@@ -106,7 +107,6 @@ if ($PSCmdlet.ParameterSetName -eq "Group") {
 }
 else {
     $users = Get-MgUser -All -Property $properties
-    $context = Get-MgContext
 
     if ($PSCmdlet.ParameterSetName -eq "Specific") {
         $users = $users | Where-Object { $UserEmail -contains $_.Mail }

--- a/script/Send-TeamsMessage.ps1
+++ b/script/Send-TeamsMessage.ps1
@@ -68,6 +68,9 @@ param (
 
 #region Global Variables
 $ErrorActionPreference = "Stop"
+$PSDefaultParameterValues[ "*Mg*:ErrorAction" ] = $ErrorActionPreference
+$PSDefaultParameterValues[ "*Mg*:Verbose" ] = $VerbosePreference
+$PSDefaultParameterValues[ "*Mg*:Debug" ] = $DebugPreference
 #endregion
 
 #region Connect
@@ -150,7 +153,7 @@ foreach ($user in $users) {
             contentType = "html"
         }
     }
-    # $chatMessage = New-MgChatMessage -ChatId $chat.Id -BodyParameter $body
+    $chatMessage = New-MgChatMessage -ChatId $chat.Id -BodyParameter $body
 
     Write-Information -InformationAction Continue -MessageData "Message sent to $($user.Mail) - $($chatMessage.Id)"
 }

--- a/script/Send-TeamsMessage.ps1
+++ b/script/Send-TeamsMessage.ps1
@@ -9,26 +9,22 @@
 PS C:\> .\Send-TeamsMessage.ps1
 cmdlet Send-TeamsMessage.ps1 at command pipeline position 1
 Supply values for the following parameters:
-MessagePath: Send-TeamsMessage.txt
-UserEmail[0]: name@domain.com
+UserEmail[0]: user1@example.com
 UserEmail[1]:
-Message sent to name@domain.com - 1712341085558
+Message sent to user1@example.com - 1712341085558
+.EXAMPLE
+PS C:\> .\Send-TeamsMessage.ps1 -UserEmail "user1@example.com","user2@example.com"
+Message sent to user1@example.com - 1712341085558
+Message sent to user2@example.com - 1712321055558
 .EXAMPLE
 PS C:\> .\Send-TeamsMessage.ps1 -All
-cmdlet Send-TeamsMessage.ps1 at command pipeline position 1
-Supply values for the following parameters:
-MessagePath: Send-TeamsMessage.txt
-Message sent to name1@domain.com - 171234108555
-Message sent to name2@domain.com - 171234101238
-Message sent to name3@domain.com - 171231234558
-Message sent to name4@domain.com - 121443105558
+Message sent to user1@example.com - 1712341085558
+Message sent to user2@example.com - 1712321055558
+Message sent to user3@example.com - 121443105558
 .EXAMPLE
 PS C:\> .\Send-TeamsMessage.ps1 -All -ExcludeDisplayName "Ernie Sesame","Karla Kolumna"
-cmdlet Send-TeamsMessage.ps1 at command pipeline position 1
-Supply values for the following parameters:
-MessagePath: Send-TeamsMessage.txt
-Message sent to name1@domain.com - 171234108555
-Message sent to name4@domain.com - 121443105558
+Message sent to user1@example.com - 1712341085558
+Message sent to user2@example.com - 1712321055558
 #>
 
 [CmdletBinding(DefaultParameterSetName = "Specific")]
@@ -41,7 +37,7 @@ param (
     $MessagePath = (Join-Path -Path $PSScriptRoot -ChildPath "MessageTemplate.txt"),
 
     # The Mail address of the user in current Tenant to send message to.
-    [Parameter(ParameterSetName = "Specific", Mandatory)]
+    [Parameter(ParameterSetName = "Specific", Mandatory, Position = 0)]
     [String[]]
     $UserEmail,
 

--- a/script/Send-TeamsMessage.ps1
+++ b/script/Send-TeamsMessage.ps1
@@ -78,7 +78,7 @@ $PSDefaultParameterValues[ "*Mg*:Debug" ] = $DebugPreference
 $additionalScope = "User.ReadBasic.All"
 if ($PSCmdlet.ParameterSetName -eq "Group") {
     $additionalScope = "GroupMember.Read.All"
-    Write-Information -InformationAction Continue -MessageData "You are using the Group parameter. This requires the Group.Read.All scope, which is an Admin scope. Make sure you have the necessary permissions to run this script."
+    Write-Information -InformationAction Continue -MessageData "You are using the Group parameter. This requires the GroupMember.Read.All scope, which is an Admin scope. Make sure you have the necessary permissions to run this script."
     Write-Information -InformationAction Continue -MessageData "If you don't have the Group.Read.All scope, you can remove the Group parameter to use the User.ReadBasic.All scope instead."
 }
 elseif ($PSBoundParameters.ContainsKey("ExcludeDisplayName")) {

--- a/script/Send-TeamsMessage.ps1
+++ b/script/Send-TeamsMessage.ps1
@@ -59,16 +59,14 @@ $ErrorActionPreference = "Stop"
 #endregion
 
 #region Connect
-$scopes = @("Chat.Create", "ChatMessage.Send", "")
+$readScope = "User.ReadBasic.All"
 if ($PSBoundParameters.ContainsKey("ExcludeDisplayName")) {
-    $scopes[2] = "User.Read.All"
+    $readScope = "User.Read.All"
     Write-Information -InformationAction Continue -MessageData "You are using the ExcludeDisplayName parameter. This requires the User.Read.All scope, which is an Admin scope. Make sure you have the necessary permissions to run this script."
     Write-Information -InformationAction Continue -MessageData "If you don't have the User.Read.All scope, you can remove the ExcludeDisplayName parameter to use the User.ReadBasic.All scope instead."
 }
-else {
-    $scopes[2] = "User.ReadBasic.All"
-}
 
+$scopes = @("Chat.Create", "ChatMessage.Send", $readScope)
 Connect-MgGraph -Scopes $scopes
 #endregion
 


### PR DESCRIPTION
To get `DisplayName` the scope `User.Read.All` is required. To use this scope you need to be an admin. So we only want to use that, when we want to Exclude DisplayNames.

Furthermore we add the ability to send messages to a specific group.